### PR TITLE
Compress assets in precompile list including require.js

### DIFF
--- a/lib/requirejs/rails/config.rb
+++ b/lib/requirejs/rails/config.rb
@@ -152,5 +152,9 @@ module Requirejs::Rails
         accum || (matcher =~ asset)
       end ? true : false
     end
+
+    def asset_precompiled?(logical_path, pathname)
+      Sprockets::Rails::Helper.assets.send(:matches_filter, Sprockets::Rails::Helper.precompile || [], logical_path, pathname)
+    end
   end
 end

--- a/lib/requirejs/rails/engine.rb
+++ b/lib/requirejs/rails/engine.rb
@@ -26,9 +26,9 @@ module Requirejs
         Rake.application.top_level_tasks.each do |task_name|
           case task_name
             when "requirejs:precompile:all"
-              unless config.requirejs.sprokets_js_compression
-                config.assets.js_compressor = false
-              end
+              # Enable class reloading so sprokets doesn't cache the assets configuration
+              # allowing settings for JS compression to be changed on a per file basis.
+              config.cache_classes = false
           end
         end if defined?(Rake.application)
 


### PR DESCRIPTION
Instead of disabling compilation completely, use js_compressor
for any asset in config.assets.precompile. This will ensure that
require.js and other assets in precompile will be compressed.
